### PR TITLE
Trim 0 from lookup name prefixes [VE-617]

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -686,7 +686,7 @@ func GenerateTokenName(namespace string, workflowName string, kindInTokenName st
 	namespaceReference := "class io.vamp.common.Namespace@" + namespace
 	lookupHashAlgorithm := "SHA1" // it is fixed
 	logging.Info("namespaceReference %v LookupHashAlgorithm %v, artifactVersion %v\n", namespaceReference, lookupHashAlgorithm, artifactVersion)
-	lookupName := strings.TrimPrefix(util.EncodeString(namespaceReference, lookupHashAlgorithm, artifactVersion), "0")
+	lookupName := util.EncodeString(namespaceReference, lookupHashAlgorithm, artifactVersion)
 
 	return fmt.Sprintf("%s/%s/%s", lookupName, kindInTokenName, workflowName)
 }

--- a/core/core.go
+++ b/core/core.go
@@ -686,7 +686,7 @@ func GenerateTokenName(namespace string, workflowName string, kindInTokenName st
 	namespaceReference := "class io.vamp.common.Namespace@" + namespace
 	lookupHashAlgorithm := "SHA1" // it is fixed
 	logging.Info("namespaceReference %v LookupHashAlgorithm %v, artifactVersion %v\n", namespaceReference, lookupHashAlgorithm, artifactVersion)
-	lookupName := util.EncodeString(namespaceReference, lookupHashAlgorithm, artifactVersion)
+	lookupName := strings.TrimPrefix(util.EncodeString(namespaceReference, lookupHashAlgorithm, artifactVersion), "0")
 
 	return fmt.Sprintf("%s/%s/%s", lookupName, kindInTokenName, workflowName)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -284,7 +284,11 @@ func EncodeString(value string, algorithm string, salt string) string {
 
 	h.Write([]byte(text))
 
-	return strings.TrimPrefix(hex.EncodeToString(h.Sum(nil)), "0")
+	result := hex.EncodeToString(h.Sum(nil))
+	if len(result) == h.Size()*2 {
+		return strings.TrimPrefix(result, "0")
+	}
+	return result
 }
 
 func RandomEncodedString(length int) string {

--- a/util/util.go
+++ b/util/util.go
@@ -284,7 +284,7 @@ func EncodeString(value string, algorithm string, salt string) string {
 
 	h.Write([]byte(text))
 
-	return hex.EncodeToString(h.Sum(nil))
+	return strings.TrimPrefix(hex.EncodeToString(h.Sum(nil)), "0")
 }
 
 func RandomEncodedString(length int) string {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -66,4 +66,10 @@ func TestEncodeString(t *testing.T) {
 	text2 := "class io.vamp.common.Namespace@vampio-testorg2-testenv"
 	result2 := util.EncodeString(text2, "SHA-1", "v1")
 	assert.Equal(t, expected2, result2)
+
+	expected3 := "6d1339c7c7a1ac54246a57320bb1dd15176ce29"
+
+	text3 := "class io.vamp.common.Namespace@vampio-organization-environment"
+	result3 := util.EncodeString(text3, "SHA-1", "v1")
+	assert.Equal(t, expected3, result3)
 }


### PR DESCRIPTION
Lookup names are compressed in Vamp by removing 0 characters.